### PR TITLE
Fix: bazel C++ tools weren't statically linked against compiler libs

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -42,20 +42,23 @@ if [[ ${HOST} =~ .*darwin.* ]]; then
     export BAZEL_BUILD_OPTS="--verbose_failures --crosstool_top=//custom_clang_toolchain:toolchain"
 else
     # The bazel binary is a self extracting zip file which contains binaries
-    # and libraries, some of which are linked to libstdc++.
-    # At runtime a compatible libstdc++ must be available for these libraries
-    # and binaries to work.
+    # and libraries, some of which are linked to libstdc++. At runtime a
+    # compatible libstdc++ must be available for these libraries and binaries
+    # to work.
+    #
     # Since the libstdc++ used by conda to build bazel is newer than the one
-    # available of some systems, for example CentOS 6, the system cannot be
-    # relied upon to provide this library.
-    # Typically libstdc++ is dynamically linked to libraries and binaries in
-    # conda packages and the RPATH of these files are patched to point to
-    # $PREFIX/lib as a relative path.
-    # Unfortunately bazel is unpacked outside of the conda environment,
-    # so this technique cannot be used.
-    # Rather libstdc++ (and libgcc) are statically linked in the binaries and
-    # libraries inside of self extracting zip and bazel itself.
+    # available on some systems, for example CentOS 6, the system cannot be
+    # relied upon to provide this library. Typically libstdc++ is dynamically
+    # linked to libraries and binaries in conda packages and the RPATH of these
+    # files are patched to point to $PREFIX/lib as a relative path.
+    #
+    # Unfortunately, bazel is unpacked outside of the conda environment, so
+    # this technique cannot be used. Rather libstdc++ (and libgcc) need to be
+    # statically linked into the binaries and libraries that are stored inside
+    # of the self-extracting zip and bazel itself.
+    #
     # Another possible technique would be:
+    #
     # * Unpack the zip after it is built
     # * Copy libstdc++ and any other libraries into the unpacked directory.
     # * Adjust the RPATH of all binaries and libraries to point to the directory
@@ -63,9 +66,9 @@ else
     # * Repack the directory as a self extracting zip
 
     # Linux - set flags for statically linking libstdc++
-    # xref: https://github.com/bazelbuild/bazel/blob/0.12.0/tools/cpp/unix_cc_configure.bzl#L257-L258
-    # xref: https://github.com/bazelbuild/bazel/blob/0.12.0/tools/cpp/lib_cc_configure.bzl#L25-L39
-    export BAZEL_LINKOPTS="-static-libgcc:-static-libstdc++:-l%:libstdc++.a:-lm:-Wl,--disable-new-dtags:-lrt"
+    # See also https://github.com/bazelbuild/bazel/issues/4137#issuecomment-610518610
+    export BAZEL_LINKOPTS="-static-libstdc++:-static-libgcc"
+    export BAZEL_LINKLIBS="-l%:libstdc++.a:-lm"
     export EXTRA_BAZEL_ARGS="--host_javabase=@local_jdk//:jdk"
 
     # -static-libstdc++ only works with g++, gcc ignores the argument.  Bazel
@@ -78,7 +81,7 @@ else
     cat > wrapper.sh << EOF
 #!/bin/bash
 if [[ "\$@" == *"params"* ]] || [[ "\$@" == *"c++"* ]] ; then
-    # At least one external project (abseil) is missing an explicit include
+    # At least one external project (abseil) is missing an explicit #include
     # <limits>. Since it seems impossible to patch abseil while it is being
     # pulled in (indirectly) through Bazel's own dependency management at
     # build time, we make the compiler include it per default.

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,7 +18,7 @@ source:
     - patches/0008-include-limits.patch
 
 build:
-  number: 0
+  number: 1
   # Missing OpenJDK >= 8 on s390x and ppc64le.
   skip: True  # [s390x or ppc64le]
   ignore_prefix_files: True


### PR DESCRIPTION
Fix to make Bazel C++ tools link statically against compiler libs.