### PR TITLE
Upgrade to bazel 5.2.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "4.2.2" %}
+{% set version = "5.2.0" %}
 
 package:
   name: bazel
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://github.com/bazelbuild/bazel/releases/download/{{ version }}/bazel-{{ version }}-dist.zip
-  sha256: 9981d0d53a356c4e87962847750a97c9e8054e460854748006c80f0d7e2b2d33
+  sha256: 820a94dbb14071ed6d8c266cf0c080ecb265a5eea65307579489c4662c2d582a
   patches:
     - patches/0001-allow-args-to-be-passed-to-bazel_build.patch  # [unix]
     - patches/0002-do-not-use-enable-gold-unless-supported.patch  # [unix]
@@ -15,7 +15,6 @@ source:
     - patches/0005-fix_netrc_protocol.patch  # [osx]
     - patches/0006-missing_inttype_h.patch
     - patches/0007-patch2.patch
-    - patches/0008-include-limits.patch
 
 build:
   number: 1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,7 +16,7 @@ source:
     - patches/0007-patch2.patch
 
 build:
-  number: 1
+  number: 0
   # Missing OpenJDK >= 8 on s390x and ppc64le.
   skip: True  # [s390x or ppc64le]
   ignore_prefix_files: True
@@ -54,7 +54,7 @@ test:
     # unzip -p bin/bazel embedded_tools/tools/cpp/unix_cc_configure.bzl | grep stdc++
 
 about:
-  home: https://www.bazel.io/
+  home: https://bazel.build/
   license: Apache-2.0
   license_family: Apache
   license_file: LICENSE
@@ -65,7 +65,7 @@ about:
     client applications for both Android and iOS platforms. It also provides an
     extensible framework that you can use to develop your own build rules.
   dev_url: https://github.com/bazelbuild/bazel
-  doc_url: https://www.bazel.io/versions/master/docs/install.html
+  doc_url: https://bazel.build/docs
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,6 @@ source:
   patches:
     - patches/0001-allow-args-to-be-passed-to-bazel_build.patch  # [unix]
     - patches/0002-do-not-use-enable-gold-unless-supported.patch  # [unix]
-    - patches/0003-Use-LSFindApplicationForInfo-for-locating-xcode.patch  # [osx]
     - patches/0004-link-against-iokit.patch  # [osx]
     - patches/0005-fix_netrc_protocol.patch  # [osx]
     - patches/0006-missing_inttype_h.patch


### PR DESCRIPTION
Upgrade to 5.2.0. All patches apply cleanly, literally no changes required.