### PR TITLE
Rebuild because OSX artifacts didn't show up

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,6 +17,7 @@ source:
 
 build:
   number: 0
+  # trigger: 1
   # Missing OpenJDK >= 8 on s390x and ppc64le.
   skip: True  # [s390x or ppc64le]
   ignore_prefix_files: True


### PR DESCRIPTION
The original build was done [here](https://github.com/AnacondaRecipes/bazel-feedstock/pull/14), but MacOS artifacts weren't produced.