### PR TITLE
Update bazel to 5.4.1

### DIFF
--- a/recipe/custom_clang_toolchain/CROSSTOOL.template
+++ b/recipe/custom_clang_toolchain/CROSSTOOL.template
@@ -41,7 +41,7 @@ toolchain {
   linker_flag: "-lc"
   linker_flag: "-isysroot${CONDA_BUILD_SYSROOT}"
   cxx_builtin_include_directory: "${PREFIX}/include/c++/v1"
-  cxx_builtin_include_directory: "${PREFIX}/lib/clang/12.0.0/include"
+  cxx_builtin_include_directory: "${PREFIX}/lib/clang/14.0.6/include"
   cxx_builtin_include_directory: "${CONDA_BUILD_SYSROOT}/usr/include"
   cxx_builtin_include_directory: "${CONDA_BUILD_SYSROOT}/System/Library/Frameworks"
   objcopy_embed_flag: "-I"

--- a/recipe/custom_clang_toolchain/cc_toolchain_config.bzl
+++ b/recipe/custom_clang_toolchain/cc_toolchain_config.bzl
@@ -196,7 +196,7 @@ def _impl(ctx):
                             "-isystem",
                             "${BUILD_PREFIX}/include/c++/v1",
                             "-isystem",
-                            "${BUILD_PREFIX}/lib/clang/12.0.0/include",
+                            "${BUILD_PREFIX}/lib/clang/14.0.6/include",
                             "-isystem",
                             "${CONDA_BUILD_SYSROOT}/usr/include",
                             "-isystem",
@@ -333,7 +333,7 @@ def _impl(ctx):
     cxx_builtin_include_directories = [
         "${CONDA_BUILD_SYSROOT}/System/Library/Frameworks",
         "${CONDA_BUILD_SYSROOT}/usr/include",
-        "${BUILD_PREFIX}/lib/clang/12.0.0/include",
+        "${BUILD_PREFIX}/lib/clang/14.0.6/include",
         "${BUILD_PREFIX}/include/c++/v1",
     ]
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "5.2.0" %}
+{% set version = "5.4.1" %}
 
 package:
   name: bazel

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -46,13 +46,6 @@ test:
   requires:
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
-  commands:
-    - bazel -h
-    - readelf -d $PREFIX/bin/bazel  # [linux]
-    - conda inspect linkages -p $PREFIX bazel # [unix]
-    # manually check that -lstdc++ appears in the bundled unix_cc_configure.bzl
-    # tar xf /path/to/pkgs/bazel-0.5.4-hf484d3e_0.tar.bz2 bin/bazel
-    # unzip -p bin/bazel embedded_tools/tools/cpp/unix_cc_configure.bzl | grep stdc++
 
 about:
   home: https://bazel.build/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,7 +17,6 @@ source:
 
 build:
   number: 0
-  # trigger: 1
   # Missing OpenJDK >= 8 on s390x and ppc64le.
   skip: True  # [s390x or ppc64le]
   ignore_prefix_files: True

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -32,7 +32,7 @@ requirements:
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
     - patch  # [unix]
-    - python >=3
+    - python
   host:
     - openjdk >=8
     - posix  # [win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://github.com/bazelbuild/bazel/releases/download/{{ version }}/bazel-{{ version }}-dist.zip
-  sha256: 820a94dbb14071ed6d8c266cf0c080ecb265a5eea65307579489c4662c2d582a
+  sha256: dcff6935756aa7aca4fc569bb2bd26e1537f0b1f6d1bda5f2b200fa835cc507f
   patches:
     - patches/0001-allow-args-to-be-passed-to-bazel_build.patch  # [unix]
     - patches/0002-do-not-use-enable-gold-unless-supported.patch  # [unix]

--- a/recipe/run_test.bat
+++ b/recipe/run_test.bat
@@ -1,0 +1,4 @@
+bazel -h
+if errorlevel 1 exit 1
+
+exit 0

--- a/recipe/run_test.sh
+++ b/recipe/run_test.sh
@@ -3,6 +3,8 @@
 # https://docs.bazel.build/versions/master/tutorial/cpp.html
 set -x
 
+bazel -h
+
 cp -r ${RECIPE_DIR}/tutorial .
 cd tutorial
 declare -a BAZEL_BUILD_OPTS


### PR DESCRIPTION
### Changes
- Updated `bazel` to `5.4.1`
- Refactored & removed unused tests and stale comments
- Updated `clang` toolchain version to `14.0.6` for `osx`

### Links
- GitHub: https://github.com/bazelbuild/bazel/tree/5.4.1
- Changelog: https://github.com/bazelbuild/bazel/releases/tag/5.4.1

### Notes
- According to the release notes, this release is fully backwards-compatible with `bazel 5.0`.
- As far as I know, we do need `posix` (which brings in the `m2` commands) in the host/run section for `win`, despite linter complaints.
- A few of the host packages are not pinned, leading to linter complaints. I do not see that we are pinning these specific packages anywhere else, so I have left them as-is.
- ❗ **The `osx` builds _are_ succeeding** ❗ , but the cleanup for the build fails after the package has been created and successfully tested. We don't have a workaround at this time.
 Edit: Regarding the `osx` issue, `bazel clean --expunge` and `bazel shutdown` was tried as a workaround, but did not solve the issue and was removed.