### PR TITLE
Bazel v6.5.0 Rebuild 

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,5 @@
+# TODO: Windows code signing is currently disabled as it breaks the build.
+# Similar to https://github.com/bazelbuild/bazel/issues/600 when the binary is stripped.
+# This should be removed once https://anaconda.atlassian.net/browse/PKG-5977 is unblocked.
 content_signing:
     win-64: False

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+content_signing:
+    win-64: False

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
     - patches/0004-link-against-iokit.patch                      # [osx]
 
 build:
-  number: 0
+  number: 1
   # Missing OpenJDK >= 8 on s390x and ppc64le.
   skip: True  # [s390x or ppc64le]
   ignore_prefix_files: True


### PR DESCRIPTION
Bazel v6.5.0b1 

**Destination channel:** defaults

### Links

- [PKG-5929](https://github.com/AnacondaRecipes/bazel-feedstock/tree/PKG-5929)
- Relevant PRs:
  - https://github.com/AnacondaRecipes/bazel-feedstock/pull/19
- https://staging.continuum.io/prefect/fs/bazel-feedstock/pr20/31c8052

### Explanation of changes:

- The current version of bazel v6.5.0 on defaults is broken on windows. This has been narrowed down to something in the signing process corrupting the self extracting zip file `bazel.exe`.
     - Currently if you run `conda install bazel==6.5.0` and `bazel --version` you will get the following error:
          ```
         file is invalid or corrupted (missing end of central directory record)
        Opening zip "C:\miniconda3\envs\test\Library\bin\bazel.exe": Cannot find central directory
        FATAL: Failed to open 'C:\miniconda3\envs\test\Library\bin\bazel.exe' as a zip file: success
        ```
- Bump build number and disable signing for now. 

### Notes:
- I've tested this on Windows using:
```
conda install --channel https://staging.continuum.io/prefect/fs/bazel-feedstock/pr20/31c8052 bazel==6.5.0 -y
bazel --version
```
- As in the previous PR, the OSX builds successfully and pushes to the staging channel, but fails to cleanup. 
- An additional ticket will be created to find the root cause and re-update this recipe to sign again. 

[PKG-5929]: https://anaconda.atlassian.net/browse/PKG-5929?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ