### PR TITLE
rebuild with latest protobuf/abseil/grpc

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -9,3 +9,7 @@ aggregate_check: false
 build_parameters:
   - "--suppress-variables"
   - "--skip-existing"
+
+channels:
+  - https://staging.continuum.io/pbp/fs/singlejar-feedstock/pr3/7062f26
+  - https://staging.continuum.io/pbp/fs/grpc_java_plugin-feedstock/pr5/2bc7bca

--- a/abs.yaml
+++ b/abs.yaml
@@ -9,7 +9,3 @@ aggregate_check: false
 build_parameters:
   - "--suppress-variables"
   - "--skip-existing"
-
-channels:
-  - https://staging.continuum.io/pbp/fs/singlejar-feedstock/pr3/7062f26
-  - https://staging.continuum.io/pbp/fs/grpc_java_plugin-feedstock/pr5/2bc7bca

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -28,9 +28,10 @@ source:
       # backport https://github.com/bazelbuild/bazel/commit/b817aeef1a55f8e470f91e11f7df58d4e655bbba
       - patches/0013-Removing-redundant-function-null_grpc_log_function.patch
       - patches/0014-Add-missing-absl-dependency.patch
+      - patches/0015-dont-redefine-fdopen.patch
 
 build:
-  number: 0
+  number: 1
   # TODO: Have to manually release on Windows while SIR-2384 is being worked on.
   skip: True  # [win]
   ignore_prefix_files: true

--- a/recipe/patches/0014-Add-missing-absl-dependency.patch
+++ b/recipe/patches/0014-Add-missing-absl-dependency.patch
@@ -5,30 +5,31 @@ Subject: [PATCH 14/14] Add missing absl dependency
 
 Co-Authored-By: H. Vetinari <h.vetinari@gmx.com>
 ---
- src/main/cpp/BUILD | 29 +++++++++++++++++++++++++++--
- 1 file changed, 27 insertions(+), 2 deletions(-)
+ src/main/cpp/BUILD | 30 +++++++++++++++++++++++++++---
+ 1 file changed, 28 insertions(+), 2 deletions(-)
 
 diff --git a/src/main/cpp/BUILD b/src/main/cpp/BUILD
 index efedce5da9..1fbb24c7dd 100644
 --- a/src/main/cpp/BUILD
 +++ b/src/main/cpp/BUILD
-@@ -90,6 +90,15 @@ cc_library(
+@@ -90,6 +90,16 @@ cc_library(
      ],
  )
-
+ 
 +# cannot do `[...] + select(...)` in starlark, so factor out common libraries into
 +# a variable; note that this is likely not the full list, because we're inheriting
 +# the linkopts from protobuf (see third_party/systemlibs/protobuf/BUILD), so several
 +# abseil libraries will already be present
 +_CLIENT_LINKOPTS = [
 +    "-labsl_log_severity",
++    "-labsl_strings",
 +    "-labsl_synchronization",
 +]
 +
  cc_binary(
      name = "client",
      srcs = [
-@@ -107,7 +116,7 @@ cc_binary(
+@@ -107,7 +117,7 @@ cc_binary(
          "//conditions:default": ["-Wno-sign-compare"],
      }),
      linkopts = select({
@@ -37,7 +38,7 @@ index efedce5da9..1fbb24c7dd 100644
          ],
          "//src/conditions:freebsd": [
              "-lprocstat",
-@@ -117,7 +126,7 @@ cc_binary(
+@@ -117,7 +127,7 @@ cc_binary(
          ],
          "//src/conditions:windows": [
          ],
@@ -46,7 +47,7 @@ index efedce5da9..1fbb24c7dd 100644
              "-lrt",
              "-ldl",
          ],
-@@ -138,6 +147,22 @@ cc_binary(
+@@ -138,6 +148,22 @@ cc_binary(
          "//src/main/protobuf:command_server_cc_grpc",
          "//src/main/protobuf:command_server_cc_proto",
          "//third_party/ijar:zip",
@@ -68,4 +69,4 @@ index efedce5da9..1fbb24c7dd 100644
 +        "@abseil-cpp//absl/utility:if_constexpr",
      ],
  )
-
+ 

--- a/recipe/patches/0015-dont-redefine-fdopen.patch
+++ b/recipe/patches/0015-dont-redefine-fdopen.patch
@@ -1,0 +1,28 @@
+From b0f5204db5b6b2545ee56211d4a10414bf693288 Mon Sep 17 00:00:00 2001
+From: Eric Lundby <Eric.Lundby@gmail.com>
+Date: Mon, 1 Dec 2025 09:18:51 -0700
+Subject: [PATCH 1/1] 0015-dont-redefine-fdopen
+
+On modern macOS toolchains fdopen is provided by <stdio.h>. Redefining it to NULL breaks the system header prototypes, so do not override it here. Older zlib configs used the macro for platforms without fdopen(), but that does not apply to current macOS.
+---
+ third_party/zlib/zutil.h | 4 ----
+ 1 file changed, 4 deletions(-)
+
+diff --git a/third_party/zlib/zutil.h b/third_party/zlib/zutil.h
+index 902a304cc2..cc7d7cfdee 100644
+--- a/third_party/zlib/zutil.h
++++ b/third_party/zlib/zutil.h
+@@ -142,10 +142,6 @@ extern z_const char * const z_errmsg[10]; /* indexed by 2-zlib_error */
+ #  ifndef Z_SOLO
+ #    if defined(__MWERKS__) && __dest_os != __be_os && __dest_os != __win32_os
+ #      include <unix.h> /* for fdopen */
+-#    else
+-#      ifndef fdopen
+-#        define fdopen(fd,mode) NULL /* No fdopen() */
+-#      endif
+ #    endif
+ #  endif
+ #endif
+-- 
+2.50.1 (Apple Git-155)
+


### PR DESCRIPTION
bazel protobuf 6 rebuild 

**Destination channel:** defaults

### Links

- [PKG-10685](https://anaconda.atlassian.net/browse/PKG-10685) 
- Relevant dependency PRs:
  - https://github.com/AnacondaRecipes/grpc_java_plugin-feedstock/pull/5
  - https://github.com/AnacondaRecipes/singlejar-feedstock/pull/3

### Explanation of changes:

- Bump build number to rebuild with latest abseil, protobuf, and grpc
- Adds a patch to prevent re-defining `fdopen` that is defined in `stdlib.h`
- Adds additional linking flag to the existing abseil patch. 

### Notes
- WIndows still has to be built and uploaded manually, log it attached. 
[bazel_win64.log](https://github.com/user-attachments/files/23863780/bazel_win64.log)


[PKG-10685]: https://anaconda.atlassian.net/browse/PKG-10685?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ