### PR TITLE
Update version to 8.6.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "8.3.1" %}
+{% set version = "8.6.0" %}
 {% set base_url = "https://github.com/bazelbuild/bazel/releases/download" %}
 
 package:
@@ -7,7 +7,7 @@ package:
 
 source:
   - url: {{ base_url }}/{{ version }}/bazel-{{ version }}-dist.zip
-    sha256: 79da863df05fa4de79a82c4f9d4e710766f040bc519fd8b184a4d4d51345d5ba
+    sha256: 13a84586429b6084b13bd5040d78deda58d523012151e71e7d4be0c63dd831f9
     patches:
       # bazel depends on https://github.com/conda-forge/singlejar-feedstock to build,
       # which patches the same sources; the patches from singlejar should either be
@@ -25,7 +25,7 @@ source:
       - patches/0011-Add-missing-absl-dependency.patch             # [unix]
       - patches/0012-avoid-linking-to-grpc-_unsecure-use-regular-variant-.patch     # [unix]
   - url: {{ base_url }}/{{ version }}/bazel-{{ version }}-windows-x86_64.exe  # [win]
-    sha256: a3349d1d9e2327e03344c47244d4832ab14fc78142d050aa5599d85ee26b5f79  # [win]
+    sha256: 461125dd78dd8c3c27eaf7caacf1c28b3e14062e1a42765c865738209dc820d0  # [win]
 
 build:
   number: 0
@@ -33,9 +33,6 @@ build:
   skip: true # [win]
   ignore_prefix_files: true
   binary_relocation: false
-  script_env:
-    # The release timestamp of this version.
-    - SOURCE_DATE_EPOCH="1751303700"  # 6/30/2025 1:15 PM EDT
 
 requirements:
   build:

--- a/recipe/patches/0010-Enable-new-protobuf-major-release.patch
+++ b/recipe/patches/0010-Enable-new-protobuf-major-release.patch
@@ -11,7 +11,7 @@ Subject: [PATCH 10/11] Enable new protobuf major release
  4 files changed, 26 insertions(+), 14 deletions(-)
 
 diff --git a/MODULE.bazel b/MODULE.bazel
-index e3cd20d..a3a5457 100755
+index 6b82009b09..2cbd91a62c 100644
 --- a/MODULE.bazel
 +++ b/MODULE.bazel
 @@ -15,8 +15,8 @@ module(
@@ -31,10 +31,10 @@ index e3cd20d..a3a5457 100755
  bazel_dep(name = "with_cfg.bzl", version = "0.6.0")
 -bazel_dep(name = "abseil-cpp", version = "20240722.0.bcr.2")
 +bazel_dep(name = "abseil-cpp", version = "ABSEIL_VERSION")
- bazel_dep(name = "rules_shell", version = "0.3.0")
+ bazel_dep(name = "rules_shell", version = "0.2.0")
  bazel_dep(name = "chicory", version = "1.1.0")
  
-@@ -42,7 +42,7 @@ bazel_dep(name = "apple_support", version = "1.18.1")
+@@ -42,7 +42,7 @@ bazel_dep(name = "apple_support", version = "1.23.1")
  bazel_dep(name = "rules_cc", version = "0.1.1")
  
  # repo_name needs to be used, until WORKSPACE mode is to be supported in bazel_tools
@@ -43,7 +43,7 @@ index e3cd20d..a3a5457 100755
  local_path_override(
      module_name = "protobuf",
      path = "./third_party/systemlibs/protobuf",
-@@ -88,8 +88,8 @@ local_path_override(
+@@ -100,8 +100,8 @@ local_path_override(
  # but are required for visibility from DIST_ARCHIVE_REPOS in repositories.bzl
  bazel_dep(name = "rules_apple", version = "3.16.0")
  bazel_dep(name = "bazel_features", version = "1.30.0")
@@ -65,7 +65,7 @@ index bd7a639..7759615 100755
 +# The bootstrapped Bazel has no embedded version, so native.bazel_version returns "".
 +# bazel_features treats "" as a dev version (999999.999999.999999), causing rules_cc's
 +# compatibility proxy to incorrectly select the Bazel 9+ code path.
-+export BAZEL_DEV_VERSION_OVERRIDE="8.3.1"
++export BAZEL_DEV_VERSION_OVERRIDE="8.6.0"
 +
 +# Make Java code compatible with newer protobuf release now as the bootstrap builds with the old release
 +sed -i 's/includingDefaultValueFields/alwaysPrintFieldsWithNoPresence/g' src/main/java/com/google/devtools/build/lib/util/io/MessageOutputStreamWrapper.java

--- a/recipe/patches/0011-Add-missing-absl-dependency.patch
+++ b/recipe/patches/0011-Add-missing-absl-dependency.patch
@@ -9,7 +9,7 @@ Subject: [PATCH 11/11] Add missing absl dependency
  2 files changed, 27 insertions(+), 3 deletions(-)
 
 diff --git a/MODULE.bazel b/MODULE.bazel
-index a3a5457079..69d09372b5 100644
+index 2cbd91a62c..f78f4137dd 100644
 --- a/MODULE.bazel
 +++ b/MODULE.bazel
 @@ -14,13 +14,13 @@ module(
@@ -29,7 +29,7 @@ index a3a5457079..69d09372b5 100644
  bazel_dep(name = "zstd-jni", version = "1.5.6-9")
  bazel_dep(name = "blake3", version = "1.5.1.bcr.1")
  bazel_dep(name = "zlib", version = "1.3.1.bcr.5")
-@@ -28,9 +28,10 @@ bazel_dep(name = "rules_java", version = "8.12.0")
+@@ -28,9 +28,10 @@ bazel_dep(name = "rules_java", version = "8.14.0")
  bazel_dep(name = "rules_graalvm", version = "0.11.1")
  bazel_dep(name = "rules_proto", version = "7.0.2")
  bazel_dep(name = "rules_jvm_external", version = "6.0")
@@ -41,11 +41,11 @@ index a3a5457079..69d09372b5 100644
 +bazel_dep(name = "googleapis-grpc-java", version = "1.0.0")
  bazel_dep(name = "with_cfg.bzl", version = "0.6.0")
  bazel_dep(name = "abseil-cpp", version = "ABSEIL_VERSION")
- bazel_dep(name = "rules_shell", version = "0.3.0")
+ bazel_dep(name = "rules_shell", version = "0.2.0")
 @@ -39,7 +40,7 @@ bazel_dep(name = "chicory", version = "1.1.0")
  # Depend on apple_support first and then rules_cc so that the Xcode toolchain
  # from apple_support wins over the generic Unix toolchain from rules_cc.
- bazel_dep(name = "apple_support", version = "1.18.1")
+ bazel_dep(name = "apple_support", version = "1.23.1")
 -bazel_dep(name = "rules_cc", version = "0.1.1")
 +bazel_dep(name = "rules_cc", version = "0.2.9")
  


### PR DESCRIPTION
bazel 8.6.0

**Destination channel:**  defaults

### Links

- [PKG-12756](https://anaconda.atlassian.net/browse/PKG-12756) 
- [Upstream repository](https://github.com/bazelbuild/bazel/tree/8.6.0)

### Explanation of changes:
- New version number
- Update of patches


[PKG-12756]: https://anaconda.atlassian.net/browse/PKG-12756?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ